### PR TITLE
fix: 댓글목록 시간오류, 로그인한 닉네임 댓글 달게 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/board/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/board/detail.jsp
@@ -78,9 +78,11 @@
         <h2>댓글 목록</h2>
          <c:forEach var="comment" items="${board.comments}">
              <div class="comment-item">
-                 <strong><c:out value="${comment.member.id}" /></strong>: <br>
+                 <strong><c:out value="${currentUser.id}" /></strong> <br>
                  <c:out value="${comment.content}" /> <br>
-                 <span class="comment-date"><c:out value="${comment.regdate}" /></span>
+                 <span class="comment-date">
+                    <fmt:formatDate value="${comment.regdate}" pattern="yyyy-MM-dd HH:mm:ss" />
+                 </span>
                  <button class="comment-edit" data-id="${comment.no}">수정</button>
                  <button class="comment-delete" data-id="${comment.no}">삭제</button>
              </div>


### PR DESCRIPTION
## 개요
- 작성자 : @AnChanUng 
- 구현 기능 : 댓글작성시 로그인한 id로 댓글작성, 댓글시간오류 수정

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
